### PR TITLE
Remove CSRF token authentication

### DIFF
--- a/app/controllers/api/login_controller.rb
+++ b/app/controllers/api/login_controller.rb
@@ -1,5 +1,5 @@
 class Api::LoginController < ApplicationController
-  skip_before_action :verify_authenticity_token, :authorized, only: [:create]
+  skip_before_action :authorized, only: [:create]
 
   def create
     @user = User.find_by(username: user_login_params[:username])

--- a/app/controllers/api/register_controller.rb
+++ b/app/controllers/api/register_controller.rb
@@ -1,5 +1,5 @@
 class Api::RegisterController < ApplicationController
-  skip_before_action :verify_authenticity_token, :authorized, only: [:create]
+  skip_before_action :authorized, only: [:create]
 
   def create
     if User.exists?(username: user_params[:username])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::Base
+  skip_before_action :verify_authenticity_token
   before_action :authorized
   SECRET_KEY = Rails.application.secrets.secret_key_base. to_s
 


### PR DESCRIPTION
We authenticate with jwt in a header, so we can remove the csrf token check.