### PR TITLE
AL - Store JWT as cookie and finish styling auth

### DIFF
--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -12,7 +12,7 @@ $color-secondary-alt: #e19caf;
 $color-tertiary: lemonchiffon;
 $color-text-primary: #412031;
 $color-text-secondary: #ffffff;
-$color-error: #ef5645;
+$color-error: #ef9999;
 
 $corner-radius: 20px;
 
@@ -85,19 +85,27 @@ html, body {
     top: 24px;
 }
 
-.navbar-right-buttons {
+.navbar-right {
 	position: relative;
+	display: flex;
+	flex-direction: row;
+	align-items: center;
 	right: 36px;
 	top: 24px;
 	height: 52px;
 }
 
-.navbar-right-buttons button {
+.navbar-right p {
+	font-size: 1.6rem;
+}
+
+.navbar-right button {
 	@extend %button;
 	height: 100%;
 	margin: 0 10px;
 	padding: 0 1rem;
 	font-size: 2rem;
+	background-color: transparent;
 	color: $color-text-secondary;
 }
 
@@ -225,6 +233,10 @@ html, body {
 	padding: 24px 48px;
 }
 
+.login-form h1 {
+	margin-bottom: 12px;
+}
+
 .login-close-button {
 	@extend %button;
 	background-color: transparent;
@@ -245,6 +257,7 @@ html, body {
 	width: calc(100% - 24px);
 	margin: 5px 0;
 	text-align: center;
+	font-size: 1.5rem;
 }
 
 .login-register-toggle {
@@ -252,7 +265,7 @@ html, body {
 	display: flex;
 	flex-direction: row;
 	border-bottom: 1px solid black;
-	margin-bottom: 12px;
+	margin: 12px 0;
 }
 
 .login-register-toggle button {

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -1,4 +1,5 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
 import Routes from "../routes/Index";
 import LoginForm from "./LoginForm";
 import Navbar from "./Navbar";
@@ -8,6 +9,8 @@ export default (props) => {
     const [username, setUsername] = useState(null);
     const [role, setRole] = useState(null);
 
+    const [cookies, setCookie, removeCookie] = useCookies(["ddough-auth"]);
+
     const showLogin = () => {
         setIsLoginFormVisible(true);
     }
@@ -16,13 +19,62 @@ export default (props) => {
         setIsLoginFormVisible(false);
     }
 
+    const signOut = () => {
+        setUsername(null);
+        setRole(null);
+        removeCookie("ddough-auth");
+    }
+
+    useEffect(async () => {
+        if (cookies?.["ddough-auth"]) {
+            // Authentication cookie exists, get user information
+            const options = {
+                method: "GET",
+                headers: {
+                    "Authorization": `Bearer ${cookies["ddough-auth"]}`
+                }
+            };
+
+            try {
+                const response = await fetch("/api/user", options);
+                const responseBody = await response.json();
+    
+                switch (response.status) {
+                    case 200: {
+                        // Stored token is still valid
+                        setUsername(responseBody.username);
+                        setRole(responseBody.role);
+                        hideLogin();
+                        break;
+                    }
+                    default: {
+                        // Stored token is no longer valid
+                        removeCookie("ddough-auth");
+                        break;
+                    }
+                }
+            } catch (e) {
+                console.log("Unable to Login. Error:", e);
+            }
+        }
+    }, []);
+
     return (
         <div className="homepage-container">
-            <Navbar role={role} username={username} showLogin={showLogin} />
+            <Navbar
+                role={role}
+                username={username}
+                showLogin={showLogin}
+                signOut={signOut} />
 
             {Routes}
 
-            <LoginForm visible={isLoginFormVisible} setRole={setRole} setUsername={setUsername} hideLogin={hideLogin} />
+            <LoginForm
+                visible={isLoginFormVisible}
+                setRole={setRole}
+                setUsername={setUsername}
+                setCookie={setCookie}
+                hideLogin={hideLogin} />
         </div>
     );
 };

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -65,7 +65,8 @@ export default (props) => {
                 role={role}
                 username={username}
                 showLogin={showLogin}
-                signOut={signOut} />
+                signOut={signOut}
+            />
 
             {Routes}
 
@@ -74,7 +75,8 @@ export default (props) => {
                 setRole={setRole}
                 setUsername={setUsername}
                 setCookie={setCookie}
-                hideLogin={hideLogin} />
+                hideLogin={hideLogin}
+            />
         </div>
     );
 };

--- a/app/javascript/components/LoginForm.jsx
+++ b/app/javascript/components/LoginForm.jsx
@@ -25,10 +25,10 @@ export default (props) => {
 
         try {
             const response = await fetch("/api/login", options);
-            const responseBody = await response.json();
 
             switch (response.status) {
                 case 202: {
+                    const responseBody = await response.json();
                     const cookieOptions = {
                         path: "/",
                         expires: new Date(responseBody.exp)
@@ -73,10 +73,10 @@ export default (props) => {
 
         try {
             const response = await fetch("/api/register", options);
-            const responseBody = await response.json();
 
             switch (response.status) {
                 case 201: {
+                    const responseBody = await response.json();
                     const cookieOptions = {
                         path: "/",
                         expires: new Date(responseBody.exp)

--- a/app/javascript/components/LoginForm.jsx
+++ b/app/javascript/components/LoginForm.jsx
@@ -26,25 +26,28 @@ export default (props) => {
         try {
             const response = await fetch("/api/login", options);
             const responseBody = await response.json();
-            console.log(responseBody);
 
             switch (response.status) {
                 case 202: {
-                    console.log("Success!");
+                    const cookieOptions = {
+                        path: "/",
+                        expires: new Date(responseBody.exp)
+                    };
+                    
+                    props.setCookie("ddough-auth", responseBody.jwt, cookieOptions);
                     props.setUsername(responseBody.user.username);
                     props.setRole(responseBody.user.role);
                     props.hideLogin();
                     break;
                 }
                 default: {
-                    console.log("Failure!");
                     setErrorMessage(responseBody?.message);
                     break;
                 }
             }
         } catch (e) {
 			setErrorMessage("An error occurred during login");
-			console.log("Unable to Login. Error:", e);
+			console.log("Unable to login. Error:", e);
 		}
     }
 
@@ -71,25 +74,28 @@ export default (props) => {
         try {
             const response = await fetch("/api/register", options);
             const responseBody = await response.json();
-            console.log(responseBody);
 
             switch (response.status) {
                 case 201: {
-                    console.log("Success!");
+                    const cookieOptions = {
+                        path: "/",
+                        expires: new Date(responseBody.exp)
+                    };
+                    
+                    props.setCookie("ddough-auth", responseBody.jwt, cookieOptions);
                     props.setUsername(responseBody.user.username);
                     props.setRole(responseBody.user.role);
                     props.hideLogin();
                     break;
                 }
                 default: {
-                    console.log("Failure!");
                     setErrorMessage(responseBody?.message);
                     break;
                 }
             }
         } catch (e) {
-			setErrorMessage("An error occurred during login");
-			console.log("Unable to Login. Error:", e);
+			setErrorMessage("An error occurred during registration");
+			console.log("Unable to register. Error:", e);
 		}
     }
     
@@ -121,9 +127,10 @@ export default (props) => {
 
                         <form onSubmit={registerMode ? registerHandler : loginHandler}>
                             <label htmlFor="username" className="input-label">Username</label>
-                            <input type="text" name="username" className="input-field" />
+                            <input type="text" name="username" autoComplete="username" className="input-field" />
                             <label htmlFor="password" className="input-label">Password</label>
-                            <input type="password" name="password" className="input-field" />
+                            <input type="password" name="password" className="input-field"
+                                autoComplete={registerMode ? "new-password" : "currentPassword"} />
 
                             {registerMode &&
                                 <>

--- a/app/javascript/components/Navbar.jsx
+++ b/app/javascript/components/Navbar.jsx
@@ -4,11 +4,11 @@ import Logo from "images/ddough_logo.PNG";
 export default(props) => (
 	<div className={props.role === "seller" ? "navbar-container-seller" : "navbar-container-buyer"}>
 		<img src={Logo} className="navbar-logo" alt="DDough logo, a D-shaped donut" />
-		<div className="navbar-right-buttons">
+		<div className="navbar-right">
 			{props.username ?
 				<>
-					<p>Logged in as {props.username}</p>
-					<button>Sign out</button>
+					<p>Signed in as {props.username}</p>
+					<button onClick={props.signOut}>Sign out</button>
 				</>
 			:
 				<button onClick={props.showLogin}>Sign in</button>

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "babel-plugin-transform-react-remove-prop-types": "^0.4.24",
     "prop-types": "^15.7.2",
     "react": "^17.0.2",
+    "react-cookie": "^4.1.1",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.3.0",
     "react_ujs": "^2.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1043,6 +1043,11 @@
     webpack-cli "^3.3.12"
     webpack-sources "^1.4.3"
 
+"@types/cookie@^0.3.3":
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.3.3.tgz#85bc74ba782fb7aa3a514d11767832b0e3bc6803"
+  integrity sha512-LKVP3cgXBT9RYj+t+9FDKwS5tdI+rPBXaNSkma7hvqy35lc7mAokC2zsqWJH0LaqIt3B962nuYI77hsJoT1gow==
+
 "@types/glob@^7.1.1":
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/@types/glob/-/glob-7.2.0.tgz#bc1b5bf3aa92f25bd5dd39f35c57361bdce5b2eb"
@@ -1050,6 +1055,14 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
+
+"@types/hoist-non-react-statics@^3.0.1":
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
+  integrity sha512-iMIqiko6ooLrTh1joXodJK5X9xeEALT1kM5G3ZLhD3hszxBdIEd5C75U834D9mLcINgD4OyZf5uQXjkuYydWvA==
+  dependencies:
+    "@types/react" "*"
+    hoist-non-react-statics "^3.3.0"
 
 "@types/json-schema@^7.0.5", "@types/json-schema@^7.0.8":
   version "7.0.9"
@@ -1071,10 +1084,29 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/prop-types@*":
+  version "15.7.4"
+  resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.4.tgz#fcf7205c25dff795ee79af1e30da2c9790808f11"
+  integrity sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==
+
 "@types/q@^1.5.1":
   version "1.5.5"
   resolved "https://registry.yarnpkg.com/@types/q/-/q-1.5.5.tgz#75a2a8e7d8ab4b230414505d92335d1dcb53a6df"
   integrity sha512-L28j2FcJfSZOnL1WBjDYp2vUHCeIFlyYI/53EwD/rKUBQ7MtUUfbQWiyKJGpcnv4/WgrhWsFKrcPstcAt/J0tQ==
+
+"@types/react@*":
+  version "17.0.34"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.34.tgz#797b66d359b692e3f19991b6b07e4b0c706c0102"
+  integrity sha512-46FEGrMjc2+8XhHXILr+3+/sTe3OfzSPU9YGKILLrUYbQ1CLQC9Daqo1KzENGXAWwrFwiY0l4ZbF20gRvgpWTg==
+  dependencies:
+    "@types/prop-types" "*"
+    "@types/scheduler" "*"
+    csstype "^3.0.2"
+
+"@types/scheduler@*":
+  version "0.16.2"
+  resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
+  integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
 "@webassemblyjs/ast@1.9.0":
   version "1.9.0"
@@ -2094,6 +2126,11 @@ cookie@0.4.0:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
   integrity sha512-+Hp8fLp57wnUSt0tY0tHEXh4voZRDnoIrZPqlo3DPiI4y9lwg/jqx+1Om94/W6ZaPDOUbnjOt/99w66zk+l1Xg==
 
+cookie@^0.4.0:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.1.tgz#afd713fe26ebd21ba95ceb61f9a8116e50a537d1"
+  integrity sha512-ZwrFkGJxUR3EIoXtO+yVE69Eb7KlixbaeAWfBQB9vVsNn/o+Yw69gBWSSDK825hQNdN+wF8zELf3dFNl/kxkUA==
+
 copy-concurrently@^1.0.0:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/copy-concurrently/-/copy-concurrently-1.0.5.tgz#92297398cae34937fcafd6ec8139c18051f0b5e0"
@@ -2388,6 +2425,11 @@ csso@^4.0.2:
   integrity sha512-wvlcdIbf6pwKEk7vHj8/Bkc0B4ylXZruLvOgs9doS5eOsOpuodOV2zJChSpkp+pRpYQLQMeF04nr3Z68Sta9jA==
   dependencies:
     css-tree "^1.1.2"
+
+csstype@^3.0.2:
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.9.tgz#6410af31b26bd0520933d02cbc64fce9ce3fbf0b"
+  integrity sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -3315,7 +3357,7 @@ hmac-drbg@^1.0.1:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^3.1.0:
+hoist-non-react-statics@^3.0.0, hoist-non-react-statics@^3.1.0, hoist-non-react-statics@^3.3.0:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -5699,6 +5741,15 @@ raw-body@2.4.0:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
+react-cookie@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/react-cookie/-/react-cookie-4.1.1.tgz#832e134ad720e0de3e03deaceaab179c4061a19d"
+  integrity sha512-ffn7Y7G4bXiFbnE+dKhHhbP+b8I34mH9jqnm8Llhj89zF4nPxPutxHT1suUqMeCEhLDBI7InYwf1tpaSoK5w8A==
+  dependencies:
+    "@types/hoist-non-react-statics" "^3.0.1"
+    hoist-non-react-statics "^3.0.0"
+    universal-cookie "^4.0.0"
+
 react-dom@^17.0.2:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-17.0.2.tgz#ecffb6845e3ad8dbfcdc498f0d0a939736502c23"
@@ -6791,6 +6842,14 @@ unique-slug@^2.0.0:
   integrity sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
   dependencies:
     imurmurhash "^0.1.4"
+
+universal-cookie@^4.0.0:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/universal-cookie/-/universal-cookie-4.0.4.tgz#06e8b3625bf9af049569ef97109b4bb226ad798d"
+  integrity sha512-lbRVHoOMtItjWbM7TwDLdl8wug7izB0tq3/YVKhT/ahB4VDvWMyvnADfnJI8y6fSvsjh51Ix7lTGC6Tn4rMPhw==
+  dependencies:
+    "@types/cookie" "^0.3.3"
+    cookie "^0.4.0"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This PR adds support for storing the JWT token as a cookie for the purpose of persisting authentication after a page refresh. The navbar will also now reflect your login status at all times, even after a page refresh. 

To get the token in your code, you can do one of the following:
1. Pass `cookies` from App.js down to your component as a prop and use `cookies["ddough-auth"]`,
2. Import `useCookies` from `react-cookie` in your component and use `cookies["ddough-auth"]` from there.

Note that this change adds a new Yarn module - you'll need to do `yarn install` after pulling this change.