### PR TITLE
Fix Orders API to now display nested JSON attributes for User and Doughnut

### DIFF
--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -1,13 +1,15 @@
 class Api::OrdersController < ApplicationController
+  skip_before_action :authorized
+
   def index
     orders = Order.all
-    render json: orders
+    render json: orders, include: [:user => {:only => :username}, :doughnut => {:only => [:name, :price, :description]}]
   end
 
   def create
     order = Order.create(order_params)
     if order.id
-      render json: order
+      render json: order, include: [:user => {:only => :username}, :doughnut => {:only => [:name, :price, :description]}]
     else
       render json: { error: order.errors }
     end
@@ -16,7 +18,7 @@ class Api::OrdersController < ApplicationController
   def show
     @order ||= Order.find_by_id(params[:id])
     if @order
-      render json: @order
+      render json: @order, include: [:user => {:only => :username}, :doughnut => {:only => [:name, :price, :description]}]
     else
       render json: { error: 'Order does not exist'}, status: 404
     end

--- a/app/controllers/api/orders_controller.rb
+++ b/app/controllers/api/orders_controller.rb
@@ -3,13 +3,13 @@ class Api::OrdersController < ApplicationController
 
   def index
     orders = Order.all
-    render json: orders, include: [:user => {:only => :username}, :doughnut => {:only => [:name, :price, :description]}]
+    render json: orders, include: [:user => {:only => [:id, :username]}, :doughnut => {:only => [:id, :name, :price, :description]}], only: [:id, :created_at, :updated_at, :user, :doughnut]
   end
 
   def create
     order = Order.create(order_params)
     if order.id
-      render json: order, include: [:user => {:only => :username}, :doughnut => {:only => [:name, :price, :description]}]
+      render json: order, include: [:user => {:only => [:id, :username]}, :doughnut => {:only => [:id, :name, :price, :description]}], only: [:id, :created_at, :updated_at, :user, :doughnut]
     else
       render json: { error: order.errors }
     end
@@ -18,7 +18,7 @@ class Api::OrdersController < ApplicationController
   def show
     @order ||= Order.find_by_id(params[:id])
     if @order
-      render json: @order, include: [:user => {:only => :username}, :doughnut => {:only => [:name, :price, :description]}]
+      render json: @order, include: [:user => {:only => [:id, :username]}, :doughnut => {:only => [:id, :name, :price, :description]}], only: [:id, :created_at, :updated_at, :user, :doughnut]
     else
       render json: { error: 'Order does not exist'}, status: 404
     end


### PR DESCRIPTION
Orders API response objects will now provide the username of whoever made the order and the name/price/description of the doughnut that was ordered:

```
[
    {
        "id": 1,
        "created_at": "2021-11-12T03:43:27.937Z",
        "updated_at": "2021-11-12T03:43:27.937Z",
        "user_id": 1,
        "doughnut_id": 1,
        "user": {
            "username": "test_user"
        },
        "doughnut": {
            "name": "test_donut",
            "price": 1231.0,
            "description": "test_dsecriptpn"
        }
    }
]
```