### PR TITLE
View, create, and edit doughnuts in app

### DIFF
--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -289,6 +289,11 @@ html, body {
 		@extend %button;
 		width: 80%;
 	}
+
+	.sold-out-button {
+		@extend .buy-now-button;
+		background-color: #666666;
+	}
 }
 
 .item-card-container:hover {

--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -221,6 +221,7 @@ html, body {
 	.item-card-description {
 		@extend %description;
 		opacity: .75;
+		overflow-wrap: break-word;
 	}
 
 	.action-buttons-wrapper {

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -8,6 +8,7 @@ export default (props) => {
     const [isLoginFormVisible, setIsLoginFormVisible] = useState(false);
     const [username, setUsername] = useState(null);
     const [role, setRole] = useState(null);
+    const [userId, setUserId] = useState(null);
 
     const [cookies, setCookie, removeCookie] = useCookies(["ddough-auth"]);
 
@@ -42,8 +43,9 @@ export default (props) => {
                 switch (response.status) {
                     case 200: {
                         // Stored token is still valid
-                        setUsername(responseBody.username);
-                        setRole(responseBody.role);
+                        setUsername(responseBody.user.username);
+                        setRole(responseBody.user.role);
+                        setUserId(responseBody.user.id);
                         hideLogin();
                         break;
                     }
@@ -64,6 +66,7 @@ export default (props) => {
             <Navbar
                 role={role}
                 username={username}
+                userId={userId}
                 showLogin={showLogin}
                 signOut={signOut}
             />
@@ -75,6 +78,7 @@ export default (props) => {
                 setRole={setRole}
                 setUsername={setUsername}
                 setCookie={setCookie}
+                setUserId={setUserId}
                 hideLogin={hideLogin}
             />
         </div>

--- a/app/javascript/components/App.jsx
+++ b/app/javascript/components/App.jsx
@@ -71,7 +71,7 @@ export default (props) => {
                 signOut={signOut}
             />
 
-            <Routes role={role} />
+            <Routes role={role} userId={userId} />
 
             <LoginForm
                 visible={isLoginFormVisible}

--- a/app/javascript/components/EditItemForm.jsx
+++ b/app/javascript/components/EditItemForm.jsx
@@ -63,7 +63,7 @@ export default (props) => {
             return "Doughnut name is missing";
         } else if (isNaN(doughnut?.price) || doughnut.price < 0.01) {
             return "Doughnut price is missing or invalid"
-        } else if (isNaN(doughnut?.quantity) || doughnut.quantity < 1) {
+        } else if (isNaN(doughnut?.quantity) || doughnut.quantity < 0) {
             return "Doughnut quantity is missing or invalid"
         } else if (typeof doughnut?.description !== "string") {
             return "Doughnut description is invalid";

--- a/app/javascript/components/EditItemForm.jsx
+++ b/app/javascript/components/EditItemForm.jsx
@@ -25,7 +25,7 @@ export default (props) => {
         }
 
         const options = {
-        	method: "POST",
+        	method: props.doughnut === null ? "POST" : "PUT",
         	body: JSON.stringify(doughnut),
         	headers: {
                 "Authorization": cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null,
@@ -34,7 +34,7 @@ export default (props) => {
         };
 
         try {
-            const response = await fetch("/api/doughnuts", options);
+            const response = await fetch(`/api/doughnuts/${props?.doughnut?.id || ""}`, options);
 
             switch (response.status) {
                 case 200: {

--- a/app/javascript/components/EditItemForm.jsx
+++ b/app/javascript/components/EditItemForm.jsx
@@ -1,0 +1,103 @@
+import React, { useState } from "react";
+import { useCookies } from "react-cookie";
+
+import OverlayForm from "./OverlayForm";
+
+export default (props) => {
+    const [errorMessage, setErrorMessage] = useState(null);
+
+	const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
+
+    const submitHandler = async (e) => {
+        e.preventDefault();
+        setErrorMessage(null);
+
+        const doughnut = {
+            name: e.target[0].value.trim(),
+            price: parseFloat(e.target[1].value),
+            quantity: parseInt(e.target[2].value),
+            description: e.target[3].value.trim()
+        };
+
+        const validationErr = validateDoughnut(doughnut);
+        if (validationErr !== null) {
+            return setErrorMessage(validationErr);
+        }
+
+        const options = {
+        	method: "POST",
+        	body: JSON.stringify(doughnut),
+        	headers: {
+                "Authorization": cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null,
+                "Content-Type": "application/json"
+        	}
+        };
+
+        try {
+            const response = await fetch("/api/doughnuts", options);
+
+            switch (response.status) {
+                case 200: {
+                    props.hideEditForm();
+                    props.refreshList();
+                    break;
+                }
+                case 500: {
+                    setErrorMessage("A server error occurred");
+                    break;
+                }
+                default: {
+                    const responseBody = await response.json();
+                    setErrorMessage(responseBody?.message);
+                    break;
+                }
+            }
+        } catch (e) {
+        	setErrorMessage("An error occurred when updating the doughnut");
+        	console.log("Unable to update doughnut. Error:", e);
+        }
+    }
+
+    const validateDoughnut = (doughnut) => {
+        if (typeof doughnut?.name !== "string" || doughnut.name.length <= 0) {
+            return "Doughnut name is missing";
+        } else if (isNaN(doughnut?.price) || doughnut.price < 0.01) {
+            return "Doughnut price is missing or invalid"
+        } else if (isNaN(doughnut?.quantity) || doughnut.quantity < 1) {
+            return "Doughnut quantity is missing or invalid"
+        } else if (typeof doughnut?.description !== "string") {
+            return "Doughnut description is invalid";
+        }
+
+        return null;
+    }
+
+    return (
+        <>
+            {props.visible &&
+                <OverlayForm closeHandler={props.hideEditForm} title={props.doughnut === null
+                    ? "Create new doughnut" : `Edit ${props.doughnut.name}`}>
+                    {errorMessage &&
+                        <div className="login-error">{errorMessage}</div>
+                    }
+
+                    <form onSubmit={submitHandler}>
+                        <label htmlFor="name" className="input-label">Name</label>
+                        <input type="text" name="name" className="input-field" 
+                            defaultValue={props?.doughnut?.name || ""}/>
+                        <label htmlFor="price" className="input-label">Price</label>
+                        <input type="number" name="price" className="input-field" min="0.01" step="0.01"
+                            defaultValue={props?.doughnut?.price?.toFixed(2) || ""} />
+                        <label htmlFor="quantity" className="input-label">Quantity</label>
+                        <input type="number" name="quantity" className="input-field" min="0" step="1"
+                            defaultValue={props?.doughnut?.quantity || ""} />
+                        <label htmlFor="description" className="input-label">Description</label>
+                        <input type="text" name="description" className="input-field"
+                            defaultValue={props?.doughnut?.description || ""} />
+                        <input type="submit" value="Save Changes" className="login-button cta-button" />
+                    </form>
+                </OverlayForm>
+            }
+        </>
+    );
+}

--- a/app/javascript/components/EditItemForm.jsx
+++ b/app/javascript/components/EditItemForm.jsx
@@ -6,7 +6,7 @@ import OverlayForm from "./OverlayForm";
 export default (props) => {
     const [errorMessage, setErrorMessage] = useState(null);
 
-	const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
+    const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
 
     const submitHandler = async (e) => {
         e.preventDefault();
@@ -25,12 +25,12 @@ export default (props) => {
         }
 
         const options = {
-        	method: props.doughnut === null ? "POST" : "PUT",
-        	body: JSON.stringify(doughnut),
-        	headers: {
+            method: props.doughnut === null ? "POST" : "PUT",
+            body: JSON.stringify(doughnut),
+            headers: {
                 "Authorization": cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null,
                 "Content-Type": "application/json"
-        	}
+            }
         };
 
         try {
@@ -53,8 +53,8 @@ export default (props) => {
                 }
             }
         } catch (e) {
-        	setErrorMessage("An error occurred when updating the doughnut");
-        	console.log("Unable to update doughnut. Error:", e);
+            setErrorMessage("An error occurred when updating the doughnut");
+            console.log("Unable to update doughnut. Error:", e);
         }
     }
 

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
-import EditItemForm from "./EditItemForm";
 
+import EditItemForm from "./EditItemForm";
 import OrderList from "./OrderList";
 import StoreDisplay from "./StoreDisplay";
 
@@ -47,10 +47,8 @@ export default(props) => {
 
     const showEditForm = (id) => {
         if (id === null) {
-            console.log("Creating a new doughnut");
             setDoughnutToEdit(null);
         } else {
-            console.log(`Editing doughnut at index ${id}`);
             setDoughnutToEdit(items[id]);
         }
 
@@ -64,7 +62,7 @@ export default(props) => {
     return (
         <>
             <div className="store-container">
-                {props.role == "seller" && (<OrderList />)}
+                {props.role == "seller" && (<OrderList userId={props.userId} />)}
                 <StoreDisplay itemList={items} role={props.role} editHandler={showEditForm} />
             </div>
 

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -29,7 +29,8 @@ export default(props) => {
 
         switch (response.status) {
             case 200: {
-                setItems(await response.json());
+                const doughnuts = await response.json();
+                setItems(doughnuts.sort((a, b) => a.id - b.id));
                 break;
             }
             case 204: {

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -1,39 +1,78 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+import EditItemForm from "./EditItemForm";
 
 import OrderList from "./OrderList";
 import StoreDisplay from "./StoreDisplay";
 
 export default(props) => {
-	const MOCK_ITEMS = [
-		{
-			name: "Classic Donut",
-			price: 1.0,
-			quantity: 20,
-			description: "The classic round donut"
-		},
-		{
-			name: "Signature Ddough",
-			price: 1.2,
-			quantity: 50
-		},
-		{
-			name: "Sweet Ruby",
-			price: 1.5
-		},
-		{
-			name: "Ruby on Rails",
-			price: 2.0
-		},
-		{
-			name: "Bbough",
-			price: 1.5
-		}
-	];
+    const [isEditDoughnutVisible, setIsEditDoughnutVisible] = useState(false);
+    const [doughnutToEdit, setDoughnutToEdit] = useState(null);
+    const [items, setItems] = useState([]);
 
-	return (
-		<div className="store-container">
-			{props.role == "seller" && (<OrderList />)}
-			<StoreDisplay itemList={MOCK_ITEMS} role={props.role} />
-		</div>
-	);
+    const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
+
+    useEffect(async () => {
+        await getDoughnuts();
+    }, []);
+
+    const getDoughnuts = async () => {
+        const options = {
+            method: "GET",
+            headers: {
+                Accept: "application/json",
+                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
+            }
+        };
+
+        const response = await fetch("/api/doughnuts", options);
+
+        switch (response.status) {
+            case 200: {
+                setItems(await response.json());
+                break;
+            }
+            case 204: {
+                // There are no doughnuts
+                setItems([]);
+                break;
+            }
+            default: {
+                console.log("An error occurred!", await response.json());
+                setItems([]);
+                break;
+            }
+        }
+    }
+
+    const showEditForm = (id) => {
+        if (id === null) {
+            console.log("Creating a new doughnut");
+            setDoughnutToEdit(null);
+        } else {
+            console.log(`Editing doughnut at index ${id}`);
+            setDoughnutToEdit(items[id]);
+        }
+
+        setIsEditDoughnutVisible(true);
+    }
+
+    const hideEditForm = () => {
+        setIsEditDoughnutVisible(false);
+    }
+
+    return (
+        <>
+            <div className="store-container">
+                {props.role == "seller" && (<OrderList />)}
+                <StoreDisplay itemList={items} role={props.role} editHandler={showEditForm} />
+            </div>
+
+            <EditItemForm
+                visible={isEditDoughnutVisible}
+                hideEditForm={hideEditForm}
+                refreshList={getDoughnuts}
+                doughnut={doughnutToEdit} />
+        </>
+    );
 }

--- a/app/javascript/components/ItemCard.jsx
+++ b/app/javascript/components/ItemCard.jsx
@@ -34,7 +34,7 @@ export default(props) => {
 
 				{(props.role == "seller" && onHover) && (
 					<div className="action-buttons-wrapper">
-						<button className="edit-item-button">
+						<button className="edit-item-button" onClick={() => props.editHandler(props.idx)}>
 							<img src={EditIcon} alt="Edit donut" />
 						</button>
 						<button className="delete-item-button">
@@ -47,7 +47,7 @@ export default(props) => {
 			{(onHover && props.role != null) && (
 				<form className="purchase-form">
 					<label htmlFor="quantity" className="quantity-label">Quantity</label>
-					<input type="number" name="quantity" defaultValue={1} min={1} className="purchase-quantity" />
+					<input type="number" name="quantity" defaultValue={1} min={1} max={props?.quantity} className="purchase-quantity" />
 					<input type="submit" value="Buy Now" className="buy-now-button" />
 				</form>
 			)}

--- a/app/javascript/components/ItemCard.jsx
+++ b/app/javascript/components/ItemCard.jsx
@@ -43,11 +43,27 @@ export default(props) => {
 			</div>
 
 			{(onHover && props.role === "buyer") && (
-				<form className="purchase-form">
-					<label htmlFor="quantity" className="quantity-label">Quantity</label>
-					<input type="number" name="quantity" defaultValue={1} min={1} max={props?.quantity} className="purchase-quantity" />
-					<input type="submit" value="Buy Now" className="buy-now-button" />
-				</form>
+				<>
+					{props.quantity > 0 ?
+						<form className="purchase-form">
+							<label htmlFor="quantity" className="quantity-label">Quantity</label>
+							<input
+								type="number"
+								name="quantity"
+								defaultValue={1}
+								min={1}
+								max={props?.quantity}
+								step={1}
+								className="purchase-quantity"
+							/>
+							<input type="submit" value="Buy Now" className="buy-now-button" />
+						</form>
+					:
+						<div className="purchase-form">
+							<button className="sold-out-button">Sold Out</button>
+						</div>
+					}
+				</>
 			)}
 		</div>
 	);

--- a/app/javascript/components/ItemCard.jsx
+++ b/app/javascript/components/ItemCard.jsx
@@ -14,37 +14,35 @@ export default(props) => {
 			onMouseLeave={() => setOnHover(false)}
 		>
 			<div className="item-info-wrapper">
-				<img 
+				<img
 					src={props.img || (props.idx % 2 == 0 ? Placeholder1 : Placeholder2)}
 					alt={`Image of ${props.name}`} 
 					className="item-card-img"
 				/>
-				<div className={(onHover && props.role != null) ? " blur" : ""}>
+				<div className={(onHover && props.role === "buyer") ? " blur" : ""}>
 					<p className="item-card-name">{props.name}</p>
-					<p className="item-card-price">${props.price.toPrecision(3)}</p>
+					<p className="item-card-price">${props.price.toFixed(2)}</p>
 
 					{props.description && (
 						<p className="item-card-description">{props.description}</p>
 					)}
 				</div>
 
-				{(props.quantity && props.role == "seller") && (
-					<p className="item-card-quantity">{props.quantity}</p>
-				)}
+				<p className="item-card-quantity">{props.quantity}</p>
 
 				{(props.role == "seller" && onHover) && (
 					<div className="action-buttons-wrapper">
 						<button className="edit-item-button" onClick={() => props.editHandler(props.idx)}>
 							<img src={EditIcon} alt="Edit donut" />
 						</button>
-						<button className="delete-item-button">
+						{/* <button className="delete-item-button">
 							<img src={DeleteIcon} alt="Delete donut" />
-						</button>
+						</button> */}
 					</div>
 				)}
 			</div>
 
-			{(onHover && props.role != null) && (
+			{(onHover && props.role === "buyer") && (
 				<form className="purchase-form">
 					<label htmlFor="quantity" className="quantity-label">Quantity</label>
 					<input type="number" name="quantity" defaultValue={1} min={1} max={props?.quantity} className="purchase-quantity" />

--- a/app/javascript/components/LoginForm.jsx
+++ b/app/javascript/components/LoginForm.jsx
@@ -39,6 +39,7 @@ export default (props) => {
                     props.setCookie("ddough-auth", responseBody.jwt, cookieOptions);
                     props.setUsername(responseBody.user.username);
                     props.setRole(responseBody.user.role);
+                    props.setUserId(responseBody.user.id);
                     props.hideLogin();
                     break;
                 }
@@ -92,11 +93,13 @@ export default (props) => {
                     props.setCookie("ddough-auth", responseBody.jwt, cookieOptions);
                     props.setUsername(responseBody.user.username);
                     props.setRole(responseBody.user.role);
+                    props.setUserId(responseBody.user.id);
                     props.hideLogin();
                     break;
                 }
                 case 409: {
                     setErrorMessage("This username is taken");
+                    break;
                 }
                 case 422: {
                     const responseBody = await response.json();

--- a/app/javascript/components/Order.jsx
+++ b/app/javascript/components/Order.jsx
@@ -21,12 +21,12 @@ export default(props) => {
 				>
 					<p>
 						{item.name}({item.quantity})
-						<span>${(item.price * item.quantity).toPrecision(3)}</span>
+						<span>${(item.price * item.quantity).toFixed(2)}</span>
 					</p>
 				</div>
 			))}
 			<div className="order-total-container">
-				<p>Total:<span>${cost.toPrecision(3)}</span></p>
+				<p>Total:<span>${cost.toFixed(2)}</span></p>
 			</div>
 		</div>
 	);

--- a/app/javascript/components/OrderList.jsx
+++ b/app/javascript/components/OrderList.jsx
@@ -56,10 +56,12 @@ export default(props) => {
 
 	const [orders, setOrders] = useState(MOCK_ORDERS);
 
-	useEffect(async () => {
-		const response = await fetch("/api/orders");
-		// console.log(await response.json());
-	}, []);
+	// useEffect(async () => {
+	// 	if (props.userId !== null) {
+	// 		const response = await fetch(`/api/user/${props.userId}/orders`);
+	// 		console.log(await response.json());
+	// 	}
+	// }, [props.userId]);
 
 	return (
 		<div className="order-list-container">

--- a/app/javascript/components/StoreDisplay.jsx
+++ b/app/javascript/components/StoreDisplay.jsx
@@ -7,20 +7,21 @@ export default(props) => (
 		<div className="store-display-container">
 			<div className="store-display-wrapper">
 				{props.itemList.map((item, idx) => (
-					<ItemCard 
+					<ItemCard
 						key={item.name}
-						idx={idx} 
-						name={item.name} 
-						price={item.price} 
-						img={item.img} 
+						idx={idx}
+						name={item.name}
+						price={item.price}
+						img={item.img}
 						description={item.description}
 						quantity={item.quantity}
 						role={props.role}
+						editHandler={props.editHandler}
 					/>
 				))}
 			</div>
 			{props.role == "seller" && (
-				<button className="add-item-button">
+				<button className="add-item-button" onClick={() => props.editHandler(null)}>
 					<span>+</span>
 				</button>
 			)}

--- a/app/javascript/routes/Index.jsx
+++ b/app/javascript/routes/Index.jsx
@@ -7,7 +7,7 @@ export default function Routes(props) {
 		<Router>
 			<Switch>
 				<Route path="/">
-					<Home role={props.role} />
+					<Home role={props.role} userId={props.userId} />
 				</Route>
 			</Switch>
 		</Router>


### PR DESCRIPTION
This PR allows all users to view doughnuts available in the catalog and allows sellers to create and edit doughnuts.

Other small changes:
* Orders endpoint is now fixed to now be under /users
* Removed blur, quantity picker, and "Buy Now" button if seller
* Removed delete button
* Fixed word wrap in doughnut descriptions
* Show doughnut quantity to all users
* Show "Sold Out" button when quantity is zero
* Sort doughnuts by ID number order
* Fixed price display precision to two decimal places

Closes #28.