### PR TITLE
Shopping cart frontend

### DIFF
--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -482,3 +482,103 @@ html, body {
 		}
 	}
 }
+
+.shopping-cart-container {
+	@extend .order-list-container;
+	display: flex;
+	flex-direction: column;
+	justify-content: space-between;
+
+	.shopping-cart-title {
+		@extend %heading-l;
+	}
+
+	.shopping-cart-description {
+		@extend %description;
+	}
+
+	.shopping-cart-total {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-between;
+		margin-bottom: 15px;
+	}
+
+	.shopping-cart-purchase-button {
+		@extend %button;
+		width: 100%;
+		font-size: 2rem;
+	}
+
+	.shopping-cart-item {
+		box-shadow: 0 8px 8px rgba(0, 0, 0, .1);
+		border-radius: $corner-radius;
+		padding: 12px;
+		margin: 20px 0;
+		display: flex;
+		flex-direction: row;
+		position: relative;
+
+		.item-img {
+			margin-right: 12px;
+			position: relative;
+		}
+		
+		.item-img img {
+			height: 70px;
+			width: 70px;
+			border-radius: $corner-radius;
+		}
+
+		.item-title {
+			@extend %heading-s;
+			margin: 0;
+			margin-bottom: 4px;
+
+			span {
+				font-size: .9em;
+			}
+		}
+
+		.item-price {
+			@extend %heading-l;
+		}
+
+		.item-out-of-stock {
+			@extend %description;
+			margin: 0;
+			color: $color-error;
+		}
+
+		.item-card-quantity {
+			position: absolute;
+			right: -4px;
+			top: -4px;
+			background-color: $color-text-primary;
+			color: $color-text-secondary;
+			font-family: $body-text;
+			border-radius: 100%;
+			padding: 5px;
+			margin: 0;
+			min-width: 1.4em;
+			text-align: center;
+		}
+
+		.item-delete-button {
+			@extend .round-button;
+			width: 36px;
+			height: 36px;
+			margin: 3px 0;
+			border: solid 2px $color-primary;
+			background-color: $color-error;
+			position: absolute;
+			bottom: 10px;
+			right: 10px;
+
+			img {
+				flex-shrink: 0;
+				width: 14px;
+			}
+		}
+	}
+}

--- a/app/assets/stylesheets/homepage.scss
+++ b/app/assets/stylesheets/homepage.scss
@@ -360,7 +360,7 @@ html, body {
 	font-size: 1.2rem;
 }
 
-.login-error {
+.error-message {
 	background-color: $color-error;
 	color: $color-text-primary;
 	border: none;
@@ -371,6 +371,11 @@ html, body {
 	text-align: center;
 	font-size: 1.5rem;
 	white-space: pre;
+}
+
+.success-message {
+	@extend .error-message;
+	background-color: rgba($color-secondary, .4);
 }
 
 .login-register-toggle {
@@ -508,6 +513,11 @@ html, body {
 		@extend %button;
 		width: 100%;
 		font-size: 2rem;
+	}
+
+	.shopping-cart-purchase-button-disabled {
+		@extend .shopping-cart-purchase-button;
+		background-color: #666666;
 	}
 
 	.shopping-cart-item {

--- a/app/controllers/api/cart_controller.rb
+++ b/app/controllers/api/cart_controller.rb
@@ -10,7 +10,7 @@ class Api::CartController < ApplicationController
     # render json: items
     @cart = Cart.includes(cart_items: [:doughnut]).where(user_id: @user.id)
     render json: @cart, except: [:user_id],
-      include: [:user => {:only => [:username]}, :cart_items => {:only => [:id, :quantity, :doughnut], :include => [:doughnut => {:only => [:name, :price, :description, :quantity]}]}]
+      include: [:user => {:only => [:username]}, :cart_items => {:only => [:id, :quantity, :doughnut], :include => [:doughnut => {:only => [:name, :price, :description, :quantity, :image_url]}]}]
   end
 
   def create

--- a/app/javascript/components/EditItemForm.jsx
+++ b/app/javascript/components/EditItemForm.jsx
@@ -40,7 +40,7 @@ export default (props) => {
             switch (response.status) {
                 case 200: {
                     props.hideEditForm();
-                    props.refreshList();
+                    props.refreshDoughnuts();
                     break;
                 }
                 case 500: {
@@ -81,7 +81,7 @@ export default (props) => {
                 <OverlayForm closeHandler={props.hideEditForm} title={props.doughnut === null
                     ? "Create new doughnut" : `Edit ${props.doughnut.name}`}>
                     {errorMessage &&
-                        <div className="login-error">{errorMessage}</div>
+                        <div className="error-message">{errorMessage}</div>
                     }
 
                     <form onSubmit={submitHandler}>

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -158,6 +158,7 @@ export default (props) => {
                         userId={props.userId}
                         cartItems={cartItems}
                         setCartItems={setCartItems}
+                        refreshDoughnuts={getDoughnuts}
                         refreshOrders={getOrders}
                     />
                 }

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { useCookies } from "react-cookie";
 import EditItemForm from "./EditItemForm";
 import OrderList from "./OrderList";
+import ShoppingCart from "./ShoppingCart";
 import StoreDisplay from "./StoreDisplay";
 
 export default (props) => {
@@ -59,18 +60,19 @@ export default (props) => {
     setIsEditDoughnutVisible(false);
   }
 
-  return (
-    <>
-      <div className="store-container">
-        {props.userId && (<OrderList userId={props.userId} />)}
-        <StoreDisplay itemList={items} role={props.role} editHandler={showEditForm} userId={props.userId} />
-      </div>
+    return (
+        <>
+            <div className="store-container">
+                {props.userId != null  && (<OrderList userId={props.userId} />)}
+                <StoreDisplay itemList={items} role={props.role} editHandler={showEditForm} userId={props.userId} />
+                <ShoppingCart userId={props.userId} />
+            </div>
 
-      <EditItemForm
-        visible={isEditDoughnutVisible}
-        hideEditForm={hideEditForm}
-        refreshList={getDoughnuts}
-        doughnut={doughnutToEdit} />
-    </>
-  );
+            <EditItemForm
+                visible={isEditDoughnutVisible}
+                hideEditForm={hideEditForm}
+                refreshList={getDoughnuts}
+                doughnut={doughnutToEdit} />
+        </>
+    );
 }

--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -6,73 +6,169 @@ import ShoppingCart from "./ShoppingCart";
 import StoreDisplay from "./StoreDisplay";
 
 export default (props) => {
-  const [isEditDoughnutVisible, setIsEditDoughnutVisible] = useState(false);
-  const [doughnutToEdit, setDoughnutToEdit] = useState(null);
-  const [items, setItems] = useState([]);
+    const [isEditDoughnutVisible, setIsEditDoughnutVisible] = useState(false);
+    const [doughnutToEdit, setDoughnutToEdit] = useState(null);
+    const [items, setItems] = useState([]);
+    const [orders, setOrders] = useState([]);
+    const [cartItems, setCartItems] = useState([]);
 
-  const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
+    const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
 
-  useEffect(async () => {
-    await getDoughnuts();
-  }, []);
+    useEffect(() => {
+        getDoughnuts();
+    }, []);
 
-  const getDoughnuts = async () => {
-    const options = {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-        Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
-      }
-    };
+    useEffect(() => {
+        if (props.userId) {
+            getOrders();
+            getCart();
+        }
+    }, [props.userId]);
 
-    const response = await fetch("/api/doughnuts", options);
-
-    switch (response.status) {
-      case 200: {
-        const doughnuts = await response.json();
-        setItems(doughnuts.sort((a, b) => a.id - b.id));
-        break;
-      }
-      case 204: {
-        // There are no doughnuts
+    const getDoughnuts = async () => {
         setItems([]);
-        break;
-      }
-      default: {
-        console.log("An error occurred!", await response.json());
-        setItems([]);
-        break;
-      }
+
+        const options = {
+            method: "GET",
+            headers: {
+                Accept: "application/json",
+                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
+            }
+        };
+
+        const response = await fetch("/api/doughnuts", options);
+
+        switch (response.status) {
+            case 200: {
+                const doughnuts = await response.json();
+                setItems(doughnuts.sort((a, b) => a.id - b.id));
+                break;
+            }
+            case 204: {
+                // There are no doughnuts
+                setItems([]);
+                break;
+            }
+            default: {
+                console.log("An error occurred!", await response.json());
+                setItems([]);
+                break;
+            }
+        }
     }
-  }
 
-  const showEditForm = (idx) => {
-    if (idx === null) {
-      setDoughnutToEdit(null);
-    } else {
-      setDoughnutToEdit(items[idx]);
+    const getOrders = async () => {
+        setOrders([]);
+
+        const options = {
+            method: "GET",
+            headers: {
+                Accept: "application/json",
+                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
+            }
+        };
+
+        const response = await fetch(`/api/user/${props.userId}/orders`, options);
+
+        switch (response.status) {
+            case 200: {
+                const orders = await response.json();
+                setOrders(orders);
+                break;
+            }
+            case 204: {
+                // There are no orders
+                setOrders([]);
+                break;
+            }
+            default: {
+                console.log("An error occurred!", await response.json());
+                setOrders([]);
+                break;
+            }
+        }
     }
 
-    setIsEditDoughnutVisible(true);
-  }
+    const getCart = async () => {
+        setCartItems([]);
 
-  const hideEditForm = () => {
-    setIsEditDoughnutVisible(false);
-  }
+        const options = {
+            method: "GET",
+            headers: {
+                Accept: "application/json",
+                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
+            }
+        }
+
+        const response = await fetch(`/api/user/${props.userId}/cart`, options);
+
+        switch (response.status) {
+            case 200: {
+                const cart = await response.json();
+
+                // The response currently comes back as an array, even though each user can only have one cart.
+                // We might want to fix this in the future.
+                setCartItems(cart[0].cart_items);
+                break;
+            }
+            default: {
+                console.log("An error occurred!", await response.json());
+                setCartItems([]);
+                break;
+            }
+        }
+    }
+
+    const showEditForm = (idx) => {
+        if (idx === null) {
+            setDoughnutToEdit(null);
+        } else {
+            setDoughnutToEdit(items[idx]);
+        }
+
+        setIsEditDoughnutVisible(true);
+    }
+
+    const hideEditForm = () => {
+        setIsEditDoughnutVisible(false);
+    }
 
     return (
         <>
             <div className="store-container">
-                {props.userId != null  && (<OrderList userId={props.userId} />)}
-                <StoreDisplay itemList={items} role={props.role} editHandler={showEditForm} userId={props.userId} />
-                <ShoppingCart userId={props.userId} />
+                {props.userId != null &&
+                    <OrderList
+                        userId={props.userId}
+                        role={props.role}
+                        orders={orders}
+                    />
+                }
+
+                <StoreDisplay
+                    itemList={items}
+                    role={props.role}
+                    editHandler={showEditForm}
+                    userId={props.userId}
+                    setOrders={setOrders}
+                    refreshCart={getCart}
+                />
+
+                {props.role === "buyer" &&
+                    <ShoppingCart
+                        userId={props.userId}
+                        cartItems={cartItems}
+                        setCartItems={setCartItems}
+                        refreshOrders={getOrders}
+                    />
+                }
             </div>
 
             <EditItemForm
                 visible={isEditDoughnutVisible}
                 hideEditForm={hideEditForm}
-                refreshList={getDoughnuts}
-                doughnut={doughnutToEdit} />
+                refreshDoughnuts={getDoughnuts}
+                doughnut={doughnutToEdit}
+            />
         </>
     );
 }

--- a/app/javascript/components/ItemCard.jsx
+++ b/app/javascript/components/ItemCard.jsx
@@ -64,8 +64,8 @@ export default (props) => {
 		>
 			<div className="item-info-wrapper">
 				<img
-					src={props.image_url}
-					alt={`Image of ${props.name}`}
+					src={props.image_url !== null ? props.image_url : (props.idx % 2 == 0 ? Placeholder1 : Placeholder2)}
+					alt={`Image of ${props.name}`} 
 					className="item-card-img"
 				/>
 				<div className={(onHover && props.role === "buyer") ? " blur" : ""}>

--- a/app/javascript/components/ItemCard.jsx
+++ b/app/javascript/components/ItemCard.jsx
@@ -10,7 +10,7 @@ export default (props) => {
 	const [onHover, setOnHover] = useState(false);
 	const [errorMessage, setErrorMessage] = useState(null);
 	const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
-	const [quantity, setQuantity] = useState(props.quantity)
+	const [quantity, setQuantity] = useState(props.quantity);
 
 
 	const buyNowHandler = async (e) => {
@@ -37,7 +37,11 @@ export default (props) => {
 			switch (response.status) {
 				case 201: {
 					const responseBody = await response.json();
-					setQuantity(responseBody.order_items[0].doughnut.quantity)
+					setQuantity(responseBody.order_items[0].doughnut.quantity);
+					props.setOrders((prevState) => {
+						return [...prevState, responseBody];
+					});
+					props.refreshCart();
 					break;
 				}
 				case 500: {

--- a/app/javascript/components/LoginForm.jsx
+++ b/app/javascript/components/LoginForm.jsx
@@ -135,7 +135,7 @@ export default (props) => {
             {props.visible &&
                 <OverlayForm closeHandler={props.hideLogin} title="Sign in to DDough">
                     {errorMessage &&
-                        <div className="login-error">{errorMessage}</div>
+                        <div className="error-message">{errorMessage}</div>
                     }
 
                     <div className="login-register-toggle">

--- a/app/javascript/components/Order.jsx
+++ b/app/javascript/components/Order.jsx
@@ -6,8 +6,10 @@ export default (props) => {
   return (
     <div className="order-container">
       <p className="order-title">
-        Order#{props.orderId}{" "}
-        <span>from {props.username}</span>
+        Order #{props.orderId}{" "}
+        {props.role === "seller" &&
+          <span>from {props.username}</span>
+        }
       </p>
       <p className="order-timestamp">{props.created_by}</p>
       {props.orderedItems.map((item, idx) => {

--- a/app/javascript/components/Order.jsx
+++ b/app/javascript/components/Order.jsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 export default (props) => {
-  let cost = 0.0;
+  const getTotalPrice = () => {
+    return props.orderedItems.reduce((count, item) => count + (item.quantity * item.doughnut.price), 0);
+  }
 
   return (
     <div className="order-container">
@@ -12,22 +14,19 @@ export default (props) => {
         }
       </p>
       <p className="order-timestamp">{props.created_by}</p>
-      {props.orderedItems.map((item, idx) => {
-        cost += item.doughnut.price * item.quantity
-        return (
-          <div
-            className="order-item-container"
-            key={`order#${props.orderId}#${item.doughnut.id}`}
-          >
-            <p>
-              {item.doughnut.name}({item.quantity})
-              <span>${(item.doughnut.price * item.quantity).toFixed(2)}</span>
-            </p>
-          </div>
-        )
-      })}
+      {props.orderedItems.map((item) => 
+        <div
+          className="order-item-container"
+          key={`order#${props.orderId}#${item.doughnut.id}`}
+        >
+          <p>
+            {item.doughnut.name}({item.quantity})
+            <span>${(item.doughnut.price * item.quantity).toFixed(2)}</span>
+          </p>
+        </div>
+      )}
       <div className="order-total-container">
-        <p>Total:<span>${cost.toFixed(2)}</span></p>
+        <p>Total:<span>${getTotalPrice().toFixed(2)}</span></p>
       </div>
     </div>
   );

--- a/app/javascript/components/OrderList.jsx
+++ b/app/javascript/components/OrderList.jsx
@@ -1,58 +1,20 @@
-import React, { useEffect, useState } from "react";
+import React from "react";
 import Order from "./Order";
-import { useCookies } from "react-cookie";
 
 export default (props) => {
-  const [errorMessage, setErrorMessage] = useState(null);
-  const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
-  const [orders, setOrders] = useState([]);
-
-  useEffect(async () => {
-    await getOrders();
-  }, []);
-
-  const getOrders = async () => {
-    const options = {
-      method: "GET",
-      headers: {
-        Accept: "application/json",
-        Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
-      }
-    };
-
-    const response = await fetch(`/api/user/${props.userId}/orders`, options);
-
-    switch (response.status) {
-      case 200: {
-        const orders = await response.json();
-        setOrders(orders);
-        break;
-      }
-      case 204: {
-        // There are no orders
-        setOrders([]);
-        break;
-      }
-      default: {
-        console.log("An error occurred!", await response.json());
-        setOrders([]);
-        break;
-      }
-    }
-  }
-
-  return (
-    <div className="order-list-container">
-      <p className="order-list-title">Customer Orders</p>
-      {orders.map((order) => (
-        <Order
-          key={`order#${order.id}`}
-          orderId={order.id}
-          username={order.user?.username}
-          orderedItems={order.order_items}
-          timestamp={order.created_at}
-        />
-      ))}
-    </div>
-  );
+    return (
+        <div className="order-list-container">
+            <p className="order-list-title">{props.role === "buyer" ? "Your Orders" : "Customer Orders"}</p>
+            {props.orders.slice(0).reverse().map((order) => 
+                <Order
+                    key={`order#${order.id}`}
+                    role={props.role}
+                    orderId={order.id}
+                    username={order.user?.username}
+                    orderedItems={order.order_items}
+                    timestamp={order.created_at}
+                />
+            )}
+        </div>
+    );
 }

--- a/app/javascript/components/ShoppingCart.jsx
+++ b/app/javascript/components/ShoppingCart.jsx
@@ -1,59 +1,17 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { useCookies } from "react-cookie";
 import ShoppingCartItem from "./ShoppingCartItem";
 
 export default (props) => {
-    const [cartItems, setCartItems] = useState([]);
-    const [cartId, setCartId] = useState(null);
+    const [errorMessage, setErrorMessage] = useState(null);
+    const [successMessage, setSuccessMessage] = useState(null);
 
     const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
 
-    useEffect(async () => {
-        if (props.userId !== null) {
-            await getCart();
-        } else {
-            setCartItems([]);
-            setCartId(null);
-        }
-    }, [props.userId]);
-
-    const getCart = async () => {
-        setCartItems([]);
-        setCartId(null);
-
-        const options = {
-            method: "GET",
-            headers: {
-                Accept: "application/json",
-                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
-            }
-        }
-
-        const response = await fetch(`/api/user/${props.userId}/cart`, options);
-
-        switch (response.status) {
-            case 200: {
-                const cart = await response.json();
-
-                if (cart.length === 1) {
-                    setCartItems(cart[0].cart_items);
-                    setCartId(cart[0].id);
-                } else {
-                    console.log("Cart length was not 1");
-                }
-
-                break;
-            }
-            default: {
-                console.log("An error occurred!", await response.json());
-                setCartItems([]);
-                setCartId(null);
-                break;
-            }
-        }
-    }
-
     const deleteCartItem = async (id) => {
+        setErrorMessage(null);
+        setSuccessMessage(null);
+
         const options = {
             method: "DELETE",
             headers: {
@@ -66,23 +24,76 @@ export default (props) => {
 
         switch (response.status) {
             case 204: {
-                // Delete successful, refresh cart items
-                await getCart();
+                // Delete successful, remove this item from the displayed cart
+                props.setCartItems((prevState) => prevState.filter((item) => item.id !== id));
                 break;
             }
             default: {
                 console.log("An error occurred!", await response.json());
+                setErrorMessage("An error occurred while deleting your cart item.");
+                break;
+            }
+        }
+    }
+
+    const checkoutCart = async () => {
+        setErrorMessage(null);
+        setSuccessMessage(null);
+
+        const options = {
+            method: "POST",
+            headers: {
+                Accept: "application/json",
+                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
+            }
+        }
+
+        const response = await fetch(`/api/user/${props.userId}/cart/checkout`, options);
+
+        switch (response.status) {
+            case 200: {
+                setSuccessMessage("Order successfully placed!");
+                props.setCartItems([]);
+                props.refreshOrders();
+
+                setTimeout(() => {
+                    setSuccessMessage(null);
+                }, 15000);
+
+                break;
+            }
+            default: {
+                console.log("An error occurred!", await response.json());
+                setErrorMessage("An error occurred while checking out.");
                 break;
             }
         }
     }
 
     const getNumItemsInCart = () => {
-        return cartItems.reduce((count, item) => count + item.quantity, 0);
+        return props.cartItems.reduce((count, item) => count + item.quantity, 0);
     }
 
     const getPriceOfCart = () => {
-        return cartItems.reduce((count, item) => count + (item.quantity * item.doughnut.price), 0);
+        return props.cartItems.reduce((count, item) => count + (item.quantity * item.doughnut.price), 0);
+    }
+
+    const isCartValidForCheckout = () => {
+        // Cart must not be empty
+        if (props.cartItems.length === 0) {
+            return false;
+        }
+
+        // All items in cart must be in stock
+        const invalidItems = props.cartItems.reduce((count, item) => {
+            return count + (item.quantity > item.doughnut.quantity ? 1 : 0)
+        }, 0);
+
+        if (invalidItems > 0) {
+            return false;
+        }
+
+        return true;
     }
 
     return (
@@ -90,16 +101,22 @@ export default (props) => {
             <div>
                 <p className="shopping-cart-title">Shopping Cart ({getNumItemsInCart()})</p>
                 <p className="shopping-cart-description">
-                    {cartId === null
-                        ? "Loading your shopping cart..."
-                        : cartItems.length === 0
-                            ? "Your cart is empty."
-                            : `Your cart contains ${getNumItemsInCart()} items and costs \$${getPriceOfCart().toFixed(2)}.`
+                    {props.cartItems.length === 0
+                        ? "Your cart is empty."
+                        : `Your cart contains ${getNumItemsInCart()} items and costs \$${getPriceOfCart().toFixed(2)}.`
                     }
                 </p>
 
-                {cartItems.map((item) => 
-                    <ShoppingCartItem key={`item-${cartId}-${item.doughnut.name}`} item={item}
+                {errorMessage &&
+                    <div className="error-message">{errorMessage}</div>
+                }
+
+                {successMessage &&
+                    <div className="success-message">{successMessage}</div>
+                }
+
+                {props.cartItems.map((item) => 
+                    <ShoppingCartItem key={`item-${item.doughnut.name}`} item={item}
                         deleteHandler={deleteCartItem} />
                 )}
             </div>
@@ -108,7 +125,11 @@ export default (props) => {
                     <p className="shopping-cart-title">Total:</p>
                     <p className="shopping-cart-title">${getPriceOfCart().toFixed(2)}</p>
                 </div>
-                <button class="shopping-cart-purchase-button">Checkout</button>
+                {isCartValidForCheckout() ?
+                    <button className="shopping-cart-purchase-button" onClick={checkoutCart}>Checkout</button>
+                :
+                    <button className="shopping-cart-purchase-button-disabled">Checkout</button>
+                }
             </div>
         </div>
     )

--- a/app/javascript/components/ShoppingCart.jsx
+++ b/app/javascript/components/ShoppingCart.jsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useState } from "react";
+import { useCookies } from "react-cookie";
+import ShoppingCartItem from "./ShoppingCartItem";
+
+export default (props) => {
+    const [cartItems, setCartItems] = useState([]);
+    const [cartId, setCartId] = useState(null);
+
+    const [cookies, _setCookie, _removeCookie] = useCookies(["ddough-auth"]);
+
+    useEffect(async () => {
+        if (props.userId !== null) {
+            await getCart();
+        } else {
+            setCartItems([]);
+            setCartId(null);
+        }
+    }, [props.userId]);
+
+    const getCart = async () => {
+        setCartItems([]);
+        setCartId(null);
+
+        const options = {
+            method: "GET",
+            headers: {
+                Accept: "application/json",
+                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
+            }
+        }
+
+        const response = await fetch(`/api/user/${props.userId}/cart`, options);
+
+        switch (response.status) {
+            case 200: {
+                const cart = await response.json();
+
+                if (cart.length === 1) {
+                    setCartItems(cart[0].cart_items);
+                    setCartId(cart[0].id);
+                } else {
+                    console.log("Cart length was not 1");
+                }
+
+                break;
+            }
+            default: {
+                console.log("An error occurred!", await response.json());
+                setCartItems([]);
+                setCartId(null);
+                break;
+            }
+        }
+    }
+
+    const deleteCartItem = async (id) => {
+        const options = {
+            method: "DELETE",
+            headers: {
+                Accept: "application/json",
+                Authorization: cookies?.["ddough-auth"] !== undefined ? `Bearer ${cookies["ddough-auth"]}` : null
+            }
+        }
+
+        const response = await fetch(`/api/user/${props.userId}/cart/${id}`, options);
+
+        switch (response.status) {
+            case 204: {
+                // Delete successful, refresh cart items
+                await getCart();
+                break;
+            }
+            default: {
+                console.log("An error occurred!", await response.json());
+                break;
+            }
+        }
+    }
+
+    const getNumItemsInCart = () => {
+        return cartItems.reduce((count, item) => count + item.quantity, 0);
+    }
+
+    const getPriceOfCart = () => {
+        return cartItems.reduce((count, item) => count + (item.quantity * item.doughnut.price), 0);
+    }
+
+    return (
+        <div className="shopping-cart-container">
+            <div>
+                <p className="shopping-cart-title">Shopping Cart ({getNumItemsInCart()})</p>
+                <p className="shopping-cart-description">
+                    {cartId === null
+                        ? "Loading your shopping cart..."
+                        : cartItems.length === 0
+                            ? "Your cart is empty."
+                            : `Your cart contains ${getNumItemsInCart()} items and costs \$${getPriceOfCart().toFixed(2)}.`
+                    }
+                </p>
+
+                {cartItems.map((item) => 
+                    <ShoppingCartItem key={`item-${cartId}-${item.doughnut.name}`} item={item}
+                        deleteHandler={deleteCartItem} />
+                )}
+            </div>
+            <div>
+                <div className="shopping-cart-total">
+                    <p className="shopping-cart-title">Total:</p>
+                    <p className="shopping-cart-title">${getPriceOfCart().toFixed(2)}</p>
+                </div>
+                <button class="shopping-cart-purchase-button">Checkout</button>
+            </div>
+        </div>
+    )
+}

--- a/app/javascript/components/ShoppingCart.jsx
+++ b/app/javascript/components/ShoppingCart.jsx
@@ -54,6 +54,7 @@ export default (props) => {
             case 200: {
                 setSuccessMessage("Order successfully placed!");
                 props.setCartItems([]);
+                props.refreshDoughnuts();
                 props.refreshOrders();
 
                 setTimeout(() => {

--- a/app/javascript/components/ShoppingCartItem.jsx
+++ b/app/javascript/components/ShoppingCartItem.jsx
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import Placeholder1 from "images/item_placeholder_1.JPG";
+import Placeholder2 from "images/item_placeholder_2.JPG";
+import DeleteIcon from "images/icons/delete_icon.svg";
+
+export default (props) => {
+    const [onHover, setOnHover] = useState(false);
+
+    const getTotalPrice = () => {
+        return (props.item.quantity * props.item.doughnut.price).toFixed(2);
+    }
+
+    return (
+        <div className="shopping-cart-item" onMouseEnter={() => setOnHover(true)} onMouseLeave={() => setOnHover(false)}>
+            <div className="item-img">
+                <p className="item-card-quantity">{props.item.quantity}</p>
+                <img
+                    src={props.item.doughnut.image_url !== null ? props.item.doughnut.image_url : (props.item.id % 2 == 0 ? Placeholder1 : Placeholder2)}
+                    alt={`Image of ${props.item.doughnut.name}`}
+                />
+            </div>
+            <div>
+                <p className="item-title">{props.item.doughnut.name} x {props.item.quantity} (${props.item.doughnut.price.toFixed(2)} ea.)</p>
+                <p className="item-price">${getTotalPrice()}</p>
+                {props.item.quantity > props.item.doughnut.quantity &&
+                    <p className="item-out-of-stock">⚠ Not enough inventory!</p>
+                }
+            </div>
+            {onHover && 
+                <button className="item-delete-button" onClick={() => props.deleteHandler(props.item.id)}>
+                    <img src={DeleteIcon} alt="Delete donut" />
+                </button>
+            }
+        </div>
+    )
+}

--- a/app/javascript/components/StoreDisplay.jsx
+++ b/app/javascript/components/StoreDisplay.jsx
@@ -19,6 +19,8 @@ export default(props) => (
 						role={props.role}
 						editHandler={props.editHandler}
 						userId={props.userId}
+						setOrders={props.setOrders}
+						refreshCart={props.refreshCart}
 					/>
 				))}
 			</div>


### PR DESCRIPTION
Closes #23 

This PR introduces the shopping cart to the frontend, along with a handful of other features / changes.

Main Feature:
* Buyers can now see a new "Shopping Cart" on the right side when logged in
* Buyers can see all of their cart items and the cart total
* Buyers can delete items from the cart by hovering over an item and clicking the delete icon
* Buyers can check out an entire cart by clicking "Checkout", and will see a "Success" message for 15 seconds

Other Changes:
* Shopping cart GET endpoint now returns doughnut image URLs
* Doughnut cards now display placeholders if they don't have an image URL defined
* Major refactor of code - orders and shopping cart are now stored in state at the homepage level
* Orders now calculate total order price using the `reduce()` function
* Order list now says "Your Orders" and hides the username if you are a buyer
* Order list is now displayed in reverse so newest orders appear on top
* Using "Buy Now" now adds the newly-created order to the Orders list and refreshes the shopping cart (for inventory checking)

The only remaining feature left to be implemented is the ability to add items to the shopping cart (currently, you can only use "Buy Now" in the frontend). Additionally, there seems to be a bug where using "Buy Now" does not decrement inventory counts.