### PR TITLE
AL - Only load cart if user is a buyer

### DIFF
--- a/app/javascript/components/Home.jsx
+++ b/app/javascript/components/Home.jsx
@@ -21,7 +21,10 @@ export default (props) => {
     useEffect(() => {
         if (props.userId) {
             getOrders();
-            getCart();
+
+            if (props.role === "buyer") {
+                getCart();
+            }
         }
     }, [props.userId]);
 


### PR DESCRIPTION
A very small fix to only load the cart if the user is a buyer.
Currently logging in as a seller will attempt to load the cart, which will fail because sellers cannot have carts.