### PR TITLE
Fix for ordering doughnut that doesn't exist

### DIFF
--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,11 +1,13 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :doughnut
+  validates :doughnut, presence: true
   validates :quantity, presence: true
   validate :quantity_smaller_than_stock
 
   private
   def quantity_smaller_than_stock
+    return if (doughnut == nil)
     doughnut.with_lock do
       if quantity > doughnut.quantity
         errors.add(:quantity, "Order item quantity cannot be greater than item stock")


### PR DESCRIPTION
if doughnut_id doesn't match a doughnut, the with_lock will throw error and result in 500 return code.